### PR TITLE
plugin->custom operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ A repository for beta versions of upcoming Alpine operators, along with example 
 
 To use these operators they must first be installed onto your Alpine server. Please see the Alpine documentation for help with this step. You can find [instructions here](https://alpine.atlassian.net/wiki/display/V6/How+To+Compile+and+Run+the+Sample+Operators) under the heading *Uploading an Operator to Alpine.*
 
-These operators are developed internally using the [Alpine Plugin SDK](https://github.com/AlpineNow/PluginSDK) which you can use to develop your own custom operators. 
+These operators are developed internally using the [Alpine Custom Operator SDK](https://github.com/AlpineNow/PluginSDK) which you can use to develop your own custom operators. 


### PR DESCRIPTION
we try not to use the word "plugin" in our user-facing docs, even though it's throughout the code. For consistency we the product docs let's call it the Custom Operator SDK.