### PR TITLE
used anchor link for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Custom-Operator-Previews
 A repository for beta versions of upcoming Alpine operators, along with example Alpine workflows and dataset. As they haven't yet been thoroughly QA tested, please use them at your own risk.
 
-To use these operators they must first be installed onto your Alpine server. Please see the Alpine documentation for help with this step. You can find [instructions here](https://alpine.atlassian.net/wiki/display/V6/How+To+Compile+and+Run+the+Sample+Operators) under the heading *Uploading an Operator to Alpine.*
+To use these operators they must first be installed onto your Alpine server. Please see the Alpine documentation for help with this step. You can find [instructions here](https://alpine.atlassian.net/wiki/display/V6/How+To+Compile+and+Run+the+Sample+Operators#HowToCompileandRuntheSampleOperators-UploadinganOperatortoAlpine) under the heading *Uploading an Operator to Alpine.*
 
 These operators are developed internally using the [Alpine Custom Operator SDK](https://github.com/AlpineNow/PluginSDK) which you can use to develop your own custom operators. 


### PR DESCRIPTION
so it goes straight to the section they need, and they don't have to scroll and find the necessary heading.